### PR TITLE
Reuse Location constructors and remove FilePath property

### DIFF
--- a/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -3811,7 +3811,7 @@ public class C
                 Assert.Equal(analyzer.Descriptor.Id, diagnostic.Id);
                 Assert.Equal(LocationKind.ExternalFile, diagnostic.Location.Kind);
                 var location = (ExternalFileLocation)diagnostic.Location;
-                Assert.Equal(additionalFile.Path, location.FilePath);
+                Assert.Equal(additionalFile.Path, location.GetLineSpan().Path);
                 Assert.Equal(diagnosticSpan, location.SourceSpan);
             }
         }

--- a/src/Compilers/Core/Portable/Diagnostic/ExternalFileLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/ExternalFileLocation.cs
@@ -16,13 +16,6 @@ namespace Microsoft.CodeAnalysis
         private readonly TextSpan _sourceSpan;
         private readonly FileLinePositionSpan _lineSpan, _mappedLineSpan;
 
-        internal ExternalFileLocation(string filePath, TextSpan sourceSpan, LinePositionSpan lineSpan)
-        {
-            _sourceSpan = sourceSpan;
-            _lineSpan = new FileLinePositionSpan(filePath, lineSpan);
-            _mappedLineSpan = _lineSpan;
-        }
-
         internal ExternalFileLocation(string filePath, TextSpan sourceSpan, LinePositionSpan lineSpan, string mappedFilePath, LinePositionSpan mappedLineSpan)
         {
             _sourceSpan = sourceSpan;
@@ -39,6 +32,8 @@ namespace Microsoft.CodeAnalysis
         }
 
         public string FilePath => _lineSpan.Path;
+
+        public string MappedFilePath => _mappedLineSpan.Path;
 
         public override FileLinePositionSpan GetLineSpan()
         {

--- a/src/Compilers/Core/Portable/Diagnostic/ExternalFileLocation.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/ExternalFileLocation.cs
@@ -31,10 +31,6 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public string FilePath => _lineSpan.Path;
-
-        public string MappedFilePath => _mappedLineSpan.Path;
-
         public override FileLinePositionSpan GetLineSpan()
         {
             return _lineSpan;

--- a/src/Compilers/Core/Portable/Diagnostic/Location.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/Location.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(filePath));
             }
 
-            return new ExternalFileLocation(filePath, textSpan, lineSpan);
+            return Create(filePath, textSpan, lineSpan, filePath, lineSpan);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResultBuilder.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResultBuilder.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // Fetch the first additional file that matches diagnostic location.
                 if (diagnostic.Location is ExternalFileLocation externalFileLocation)
                 {
-                    if (_pathToAdditionalTextMap.TryGetValue(externalFileLocation.FilePath, out var additionalTexts))
+                    if (_pathToAdditionalTextMap.TryGetValue(externalFileLocation.GetLineSpan().Path, out var additionalTexts))
                     {
                         foreach (var additionalText in additionalTexts)
                         {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             else if (diagnostic.Location is ExternalFileLocation externalFileLocation)
             {
                 if (FilterFileOpt.Value.AdditionalFile == null ||
-                    !PathUtilities.Comparer.Equals(externalFileLocation.FilePath, FilterFileOpt.Value.AdditionalFile.Path))
+                    !PathUtilities.Comparer.Equals(externalFileLocation.GetLineSpan().Path, FilterFileOpt.Value.AdditionalFile.Path))
                 {
                     return false;
                 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.AnalyzerDiagnosticReporter.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.AnalyzerDiagnosticReporter.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     if (_contextFile?.AdditionalFile != null &&
                         diagnostic.Location is ExternalFileLocation externalFileLocation)
                     {
-                        return PathUtilities.Comparer.Equals(_contextFile.Value.AdditionalFile.Path, externalFileLocation.FilePath);
+                        return PathUtilities.Comparer.Equals(_contextFile.Value.AdditionalFile.Path, externalFileLocation.GetLineSpan().Path);
                     }
 
                     return false;

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
@@ -1678,7 +1678,7 @@ End Namespace
             Assert.Equal(Analyzer.Descriptor.Id, diagnostic.Id)
             Assert.Equal(LocationKind.ExternalFile, diagnostic.Location.Kind)
             Dim location = DirectCast(diagnostic.Location, ExternalFileLocation)
-            Assert.Equal(additionalFile.Path, location.FilePath)
+            Assert.Equal(additionalFile.Path, location.GetLineSpan().Path)
             Assert.Equal(expectedDiagnosticSpan, location.SourceSpan)
         End Sub
 


### PR DESCRIPTION
As the title says, this PR has a couple of suggested changes for https://github.com/dotnet/roslyn/pull/64240:
- Instead of having 2 different `ExternalLocation` constructors, we can have a single one and pass the corresponding values from `Location.Create`.
- The `FilePath` property in `ExternalLocation` seems a bit redundant since the value can be obtained with `GetLineSpan().Path`. This PR removes that property to make it explicit when we want to use the mapped file path versus the one in the primary line span.